### PR TITLE
define Maxittest module for VerboseBacktrace

### DIFF
--- a/lib/maxitest/verbose_backtrace.rb
+++ b/lib/maxitest/verbose_backtrace.rb
@@ -1,3 +1,5 @@
+
+module Maxitest ; end
 module Maxitest::VerboseBacktrace
   class NullFilter
     def self.filter(backtrace)


### PR DESCRIPTION
otherwise I get an error (but not always?) like this: 

    ruby -rbundler/setup -r./spec/require_pattern_test.rb -e
    /Users/roman/Desktop/sand/RequirePattern/.direnv/ruby-2.1.2/gems/maxitest-1.1.1/lib/maxitest/verbose_backtrace.rb:1:in `<top (required)>': uninitialized constant Maxitest (NameError)
      from /Users/roman/Desktop/sand/RequirePattern/.direnv/ruby-2.1.2/gems/maxitest-1.1.1/lib/maxitest/autorun.rb:9:in `require'
      from /Users/roman/Desktop/sand/RequirePattern/.direnv/ruby-2.1.2/gems/maxitest-1.1.1/lib/maxitest/autorun.rb:9:in `<top (required)>'
      from /Users/roman/Desktop/sand/RequirePattern/spec/require_pattern_test.rb:3:in `require'
      from /Users/roman/Desktop/sand/RequirePattern/spec/require_pattern_test.rb:3:in `<top (required)>'
      from -e:1:in `require'