### PR TITLE
Add default include path to mtest executables list for failing tests.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -24,7 +24,7 @@ task :update do
         code = "module Maxitest\n#{code.gsub(/^/, "  ").gsub(/^\s+$/, "")}\nend"
       elsif url.include?("line_plugin.rb")
         # replace ruby with mtest
-        raise unless code.sub!(%{output = "ruby \#{file} -l \#{line}"}, %{output = "mtest \#{file}:\#{line}"})
+        raise unless code.sub!(%{output = "ruby \#{file} -l \#{line}"}, %{output = "mtest -I \#{file.to_s.split('/').first} \#{file}:\#{line}"})
       end
 
       "#{url}\n# BEGIN #{do_not_modify}\n#{code.strip}\n#END #{do_not_modify}"

--- a/lib/maxitest/vendor/line.rb
+++ b/lib/maxitest/vendor/line.rb
@@ -108,7 +108,7 @@ module Minitest
         if file
           file = Pathname.new(file)
           file = file.relative_path_from(pwd) if file.absolute?
-          output = "mtest #{file}:#{line}"
+          output = "mtest -I #{file.to_s.split('/').first} #{file}:#{line}"
           output = "\e[31m#{output}\e[0m" if $stdout.tty?
           io.puts output
         end

--- a/spec/maxitest_spec.rb
+++ b/spec/maxitest_spec.rb
@@ -37,7 +37,7 @@ describe Maxitest do
 
   describe "line" do
     let(:focus) { "Focus on failing tests:" }
-    let(:expected_command) { "mtest spec/cases/line.rb:8" }
+    let(:expected_command) { "mtest -I spec spec/cases/line.rb:8" }
 
     it "prints line numbers on failed" do
       sh("ruby spec/cases/line.rb", fail: true).should include "#{focus}\n#{expected_command}"


### PR DESCRIPTION
"Focus on failing tests" part of `maxitest` returned following code in rails app:

```
Focus on failing tests:
mtest test/models/line_test.rb:5
```

If I tried to run this command it ends up with following error:

```
→ mtest test/models/line_test.rb:5
ruby -rbundler/setup ./test/models/line_test.rb -l 5
./test/models/line_test.rb:1:in `require': cannot load such file -- test_helper (LoadError)
    from ./test/models/line_test.rb:1:in `<main>'
```

After changes in this commit it returns:

```
Focus on failing tests:
mtest -I test test/models/line_test.rb:5
```

And after running this in console:

```
→ mtest -I test test/models/line_test.rb:5
ruby -rbundler/setup -I test ./test/models/line_test.rb -l 5
Run options: -l 5 --seed 1385

# Running:

F

Finished in 0.734881s, 1.3608 runs/s, 8.1646 assertions/s.

  1) Failure:
LineTest#test_fixture_should_be_valid [./test/models/line_test.rb:11]:
Failed assertion, no message given.

1 runs, 6 assertions, 1 failures, 0 errors, 0 skips
```
