### PR TITLE
Include readme in gem

### DIFF
--- a/maxitest.gemspec
+++ b/maxitest.gemspec
@@ -6,7 +6,7 @@ Gem::Specification.new name, Maxitest::VERSION do |s|
   s.authors = ["Michael Grosser"]
   s.email = "michael@grosser.it"
   s.homepage = "https://github.com/grosser/#{name}"
-  s.files = `git ls-files lib/ bin/ MIT-LICENSE`.split("\n")
+  s.files = `git ls-files lib/ bin/ MIT-LICENSE Readme.md`.split("\n")
   s.license = "MIT"
   s.executables = ["mtest"]
 


### PR DESCRIPTION
I opened the gem, expecting to read the readme on how to integrate with my project, only to find it wasn't included.