### PR TITLE
Manually call Minitest#load_plugins

### DIFF
--- a/lib/maxitest/autorun.rb
+++ b/lib/maxitest/autorun.rb
@@ -1,5 +1,8 @@
 require "minitest"
 
+# make minitest look for plugins before we manually add our own
+Minitest.load_plugins
+
 disabled_for_rails = begin
   require 'rails/version'
   Rails::VERSION::MAJOR >= 5

--- a/spec/maxitest_spec.rb
+++ b/spec/maxitest_spec.rb
@@ -46,6 +46,13 @@ describe Maxitest do
     sh("ruby spec/cases/order_dependent.rb").should include "5 runs, 1 assertions, 0 failures, 0 errors, 0 skips"
   end
 
+  it "does not interfere with other plugins" do
+    result = sh("ruby -I spec/plugins spec/cases/plain.rb")
+    result.should include "Initializing tracing plugin ..."
+    result.should include "Processing options ..."
+    result.should include "2 runs, 2 assertions, 0 failures, 0 errors, 0 skips"
+  end
+
   it "has pending" do
     result = sh("ruby spec/cases/pending.rb -v", :fail => true)
     result.should include "ArgumentError: Need a block to execute" # fails without block

--- a/spec/plugins/minitest/tracing_plugin.rb
+++ b/spec/plugins/minitest/tracing_plugin.rb
@@ -1,0 +1,9 @@
+module Minitest
+  def self.plugin_tracing_init(options)
+    puts "Initializing tracing plugin ...\n"
+  end
+
+  def self.plugin_tracing_options(opts, options)
+    puts "Processing options ... \n"
+  end
+end


### PR DESCRIPTION
- minitest calls #load_plugins at startup, but short-circuits out if
Minitest.extensions is not empty. So call it manually in autorun.rb
before pushing plugins.