### PR TITLE
do not show long backtraces for local files

### DIFF
--- a/lib/maxitest/autorun.rb
+++ b/lib/maxitest/autorun.rb
@@ -7,6 +7,7 @@ require "maxitest/let_all"
 require "maxitest/pending"
 require "maxitest/xit"
 require "maxitest/static_class_order"
+require "maxitest/shorted_backtrace"
 require "maxitest/vendor/line_describe" # not a plugin
 
 module Maxitest

--- a/lib/maxitest/shorted_backtrace.rb
+++ b/lib/maxitest/shorted_backtrace.rb
@@ -1,0 +1,8 @@
+Minitest::BacktraceFilter.send(:prepend, Module.new do
+  def filter(*)
+    backtrace = super
+    pwd = "#{Dir.pwd}/"
+    section = pwd.size..-1
+    backtrace.map { |b| b.start_with?(pwd) ? b[section] : b }
+  end
+end)

--- a/spec/cases/raise.rb
+++ b/spec/cases/raise.rb
@@ -1,0 +1,13 @@
+require "./spec/cases/helper"
+
+# cause a raise in a required file
+module Maxitest
+  class Timeout
+  end
+end
+
+describe "explode" do
+  it "explodes" do
+    require 'maxitest/timeout'
+  end
+end

--- a/spec/maxitest_spec.rb
+++ b/spec/maxitest_spec.rb
@@ -57,6 +57,15 @@ describe Maxitest do
     result.should include "3 runs, 1 assertions, 0 failures, 0 errors, 2 skips"
   end
 
+  it "shows short backtraces" do
+    sh("ruby spec/cases/raise.rb", fail: true).gsub(/:in .*/, "").should include <<-TEXT.gsub("       ", "")
+       TypeError: Timeout is not a module
+           lib/maxitest/timeout.rb:9
+           lib/maxitest/timeout.rb:4
+           spec/cases/raise.rb:11
+    TEXT
+  end
+
   describe "color" do
     it "is color-less without tty" do
       sh("ruby spec/cases/plain.rb").should include "\n2 runs, 2 assertions"


### PR DESCRIPTION
turning this on by default since it's annoying and not worth an extra require