### PR TITLE
refactor not not use class_eval

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -8,6 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [ '3.0', '3.1', '3.2' ]
         gemfile: [ '514', '515', '516', '517', '518' ]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Development
  - tested via rspec to avoid messing up our own tests by accident
  - fixes should go back to the original libraries
  - restrictive minitest dependency so nothing breaks by accident
- - ruby >=2.6
+ - ruby >=3.0
  - `rake bundle` to update all vendored gems
 
 Author
@@ -57,6 +57,6 @@ Author
  - mtest from [testrbl](https://github.com/grosser/testrbl)
  - red-green from [minitest-rg](https://github.com/blowmage/minitest-rg)
 
-[Michael Grosser](http://grosser.it)<br/>
-michael@grosser.it<br/>
-License: MIT<br/>
+[Michael Grosser](http://grosser.it)  
+michael@grosser.it  
+License: MIT

--- a/lib/maxitest/let_all.rb
+++ b/lib/maxitest/let_all.rb
@@ -1,12 +1,18 @@
-Minitest::Spec::DSL.class_eval do
-  def let_all(name, &block)
-    cache = []
-    define_method(name) do
-      if cache.empty?
-        cache[0] = instance_eval(&block)
-      else
-        cache[0]
+module Maxitest
+  module LetAll
+    def let_all(name, &block)
+      cache = []
+      define_method(name) do
+        if cache.empty?
+          cache << instance_eval(&block)
+        end
+        cache.first
       end
+    end
+    def self.included(base)
+      base.extend(self)
     end
   end
 end
+
+Minitest::Spec::DSL.include(Maxitest::LetAll)

--- a/lib/maxitest/trap.rb
+++ b/lib/maxitest/trap.rb
@@ -1,33 +1,33 @@
-Minitest::Test.class_eval do
-  alias_method :capture_exceptions_without_stop, :capture_exceptions
-  def capture_exceptions(&block)
-    capture_exceptions_without_stop(&block)
-  rescue Interrupt
-    Maxitest.interrupted = true
-    self.failures << Minitest::UnexpectedError.new($!)
-  end
-
-  alias_method :run_without_stop, :run
-  def run
-    if Maxitest.interrupted
-      # only things with class `Minitest::Skip` get counted as skips
-      # we need to raise and capture to get a skip with a backtrace
-      skip = begin
-        raise Minitest::Skip, "Maxitest::Interrupted"
-      rescue Minitest::Skip
-        $!
-      end
-      self.failures = [skip]
-      defined?(Minitest::Result) ? Minitest::Result.from(self) : self
-    else
-      run_without_stop
-    end
-  end
-end
+# frozen_string_literal: true
 
 module Maxitest
   Interrupted = Class.new(StandardError)
   class << self
     attr_accessor :interrupted
   end
+
+  module InterruptHandler
+    def capture_exceptions(&block)
+      super(&block)
+    rescue Interrupt => e
+      Maxitest.interrupted = true
+      failures << Minitest::UnexpectedError.new(e)
+    end
+
+    def run
+      if Maxitest.interrupted
+        skip = begin
+          raise Minitest::Skip, 'Maxitest::Interrupted'
+        rescue Minitest::Skip => e
+          e
+        end
+        self.failures = [skip]
+        defined?(Minitest::Result) ? Minitest::Result.from(self) : self
+      else
+        super()
+      end
+    end
+  end
 end
+
+Minitest::Test.prepend(Maxitest::InterruptHandler)

--- a/lib/maxitest/xit.rb
+++ b/lib/maxitest/xit.rb
@@ -1,9 +1,19 @@
-Minitest::Spec::DSL.class_eval do
-  def xit(*args, &block)
-    describe "skip" do
-      def setup; end
-      def teardown; end
-      it(*args)
+# frozen_string_literal: true
+
+module Maxitest
+  module XitMethod
+    def xit(*args)
+      describe 'skip' do
+        define_method(:setup) {}
+        define_method(:teardown) {}
+        it(*args)
+      end
+    end
+
+    def self.included(base)
+      base.extend(self)
     end
   end
 end
+
+Minitest::Spec::DSL.include(Maxitest::XitMethod)

--- a/spec/cases/xit.rb
+++ b/spec/cases/xit.rb
@@ -1,6 +1,10 @@
 require "./spec/cases/helper"
 
 describe 2 do
+  it 'should include the xit module' do
+    assert_includes MiniTest::Spec::DSL.included_modules, Maxitest::XitMethod
+  end
+
   xit "is even" do
     2.even?.must_equal true
   end

--- a/spec/maxitest_spec.rb
+++ b/spec/maxitest_spec.rb
@@ -55,7 +55,7 @@ describe Maxitest do
   it "does not call xit specs" do
     result = run_cmd("ruby spec/cases/xit.rb -v")
     result.should include "(no tests defined)"
-    result.should include "3 runs, 1 assertions, 0 failures, 0 errors, 2 skips"
+    result.should include "4 runs, 3 assertions, 0 failures, 0 errors, 2 skips"
   end
 
   it "shows short backtraces" do


### PR DESCRIPTION
This PR includes some refactoring that makes the code easier to read and work with.

By using the modules instead of modifying or overwriting methods directly, it's now simpler to track down where the methods come from when debugging. 