### PR TITLE
fix: use Minitest instead of MiniTest

### DIFF
--- a/lib/maxitest/autorun.rb
+++ b/lib/maxitest/autorun.rb
@@ -23,6 +23,6 @@ class << Minitest::Test
 end
 
 # do not show maxitest as causing errors, but the last line in the users code
-old = MiniTest::BacktraceFilter::MT_RE
-MiniTest::BacktraceFilter.send(:remove_const, :MT_RE)
-MiniTest::BacktraceFilter::MT_RE = Regexp.union(old, %r%lib/maxitest%)
+old = Minitest::BacktraceFilter::MT_RE
+Minitest::BacktraceFilter.send(:remove_const, :MT_RE)
+Minitest::BacktraceFilter::MT_RE = Regexp.union(old, %r%lib/maxitest%)


### PR DESCRIPTION
As of 5.3.0 (specifically commit https://github.com/grosser/maxitest/commit/665ff29319d1136a1f34ce357966dc6ebebec111), Zeitwerk is not happy with the usage of `MiniTest` instead of `Minitest`. 

Builds fail with an error like this:

```ruby
/home/circleci/project/vendor/bundle/ruby/3.1.0/gems/maxi****-5.3.0/lib/maxi****/autorun.rb:26:in `<top (required)>': uninitialized constant MiniTest (NameError)

old = MiniTest::BacktraceFilter::MT_RE
      ^^^^^^^^
Did you mean?  Mini****
               Maxi****
```

This PR fixes this by simply using the `Minitest` namespace instead.