### PR TITLE
Add support for Minitest v5.20

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '3.0', '3.1', '3.2' ]
-        gemfile: [ '514', '515', '516', '517', '518', '519' ]
+        gemfile: [ '514', '515', '516', '517', '518', '519', '520' ]
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: [ '3.0', '3.1', '3.2' ]
-        gemfile: [ '514', '515', '516', '517', '518' ]
+        gemfile: [ '514', '515', '516', '517', '518', '519' ]
 
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- support minitest 5.20
 
 # v5.3.1
 - remove MiniTest usage to make Zeitwerk happy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,11 +13,16 @@ GEM
       reline (>= 0.3.1)
     diff-lcs (1.5.0)
     io-console (0.6.0)
-    irb (1.7.0)
-      reline (>= 0.3.0)
-    minitest (5.18.1)
+    irb (1.8.3)
+      rdoc
+      reline (>= 0.3.8)
+    minitest (5.20.0)
+    psych (5.1.1.1)
+      stringio
     rake (13.0.6)
-    reline (0.3.5)
+    rdoc (6.5.0)
+      psych (>= 4.0.0)
+    reline (0.3.9)
       io-console (~> 0.5)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -28,10 +33,11 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
+    stringio (3.0.8)
 
 PLATFORMS
   ruby
@@ -44,4 +50,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.6
+   2.4.21

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     maxitest (5.3.1)
-      minitest (>= 5.14.0, < 5.20.0)
+      minitest (>= 5.14.0, < 5.21.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/514.gemfile.lock
+++ b/gemfiles/514.gemfile.lock
@@ -19,15 +19,13 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   maxitest!
@@ -36,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/gemfiles/514.gemfile.lock
+++ b/gemfiles/514.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.3.1)
-      minitest (>= 5.14.0, < 5.20.0)
+      minitest (>= 5.14.0, < 5.21.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/515.gemfile.lock
+++ b/gemfiles/515.gemfile.lock
@@ -19,15 +19,13 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   maxitest!
@@ -36,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/gemfiles/515.gemfile.lock
+++ b/gemfiles/515.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.3.1)
-      minitest (>= 5.14.0, < 5.20.0)
+      minitest (>= 5.14.0, < 5.21.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/516.gemfile.lock
+++ b/gemfiles/516.gemfile.lock
@@ -19,15 +19,13 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   maxitest!
@@ -36,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/gemfiles/516.gemfile.lock
+++ b/gemfiles/516.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.3.1)
-      minitest (>= 5.14.0, < 5.20.0)
+      minitest (>= 5.14.0, < 5.21.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/517.gemfile.lock
+++ b/gemfiles/517.gemfile.lock
@@ -19,15 +19,13 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   maxitest!
@@ -36,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/gemfiles/518.gemfile.lock
+++ b/gemfiles/518.gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.0)
-    minitest (5.18.0)
+    minitest (5.18.1)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -19,15 +19,13 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   maxitest!
@@ -36,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/gemfiles/518.gemfile.lock
+++ b/gemfiles/518.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.3.1)
-      minitest (>= 5.14.0, < 5.20.0)
+      minitest (>= 5.14.0, < 5.21.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/519.gemfile.lock
+++ b/gemfiles/519.gemfile.lock
@@ -25,7 +25,7 @@ GEM
     rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin-22
+  ruby
 
 DEPENDENCIES
   maxitest!
@@ -34,4 +34,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/gemfiles/519.gemfile.lock
+++ b/gemfiles/519.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.3.1)
-      minitest (>= 5.14.0, < 5.20.0)
+      minitest (>= 5.14.0, < 5.21.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/520.gemfile
+++ b/gemfiles/520.gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gemspec :path=>"../"
+gem "minitest", "~> 5.20.0"

--- a/gemfiles/520.gemfile.lock
+++ b/gemfiles/520.gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.0)
-    minitest (5.17.0)
+    minitest (5.20.0)
     rake (13.0.6)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
@@ -19,21 +19,19 @@ GEM
     rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-mocks (3.12.5)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
-    rspec-support (3.12.0)
+    rspec-support (3.12.1)
 
 PLATFORMS
-  arm64-darwin
-  arm64-darwin-22
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   maxitest!
-  minitest (~> 5.17.0)
+  minitest (~> 5.20.0)
   rake
   rspec
 
 BUNDLED WITH
-   2.4.12
+   2.4.21

--- a/maxitest.gemspec
+++ b/maxitest.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "maxitest", Maxitest::VERSION do |s|
   s.license = "MIT"
   s.executables = ["mtest"]
 
-  s.add_runtime_dependency "minitest", [">= 5.14.0", "< 5.20.0"]
+  s.add_runtime_dependency "minitest", [">= 5.14.0", "< 5.21.0"]
   s.required_ruby_version = '>= 3', '< 4' # mirroring minitest
 
   s.add_development_dependency "rake"

--- a/spec/maxitest_spec.rb
+++ b/spec/maxitest_spec.rb
@@ -161,10 +161,8 @@ describe Maxitest do
   describe "global_must" do
     let(:deprecated) { "DEPRECATED" }
 
-    if Gem::Version.new(Minitest::VERSION) >= Gem::Version.new("5.12.0")
-      it "complain when not used" do
-        run_cmd("ruby spec/cases/plain.rb").should include deprecated
-      end
+    it "complain when not used" do
+      run_cmd("ruby spec/cases/plain.rb").should include deprecated
     end
 
     it "does not complain when used" do
@@ -181,22 +179,16 @@ describe Maxitest do
   end
 
   describe "extra threads" do
-    if  Minitest::VERSION.start_with?("5.0")
-      it "complains" do
-        run_cmd("ruby spec/cases/threads.rb -v", fail: true).should include "Upgrade above minitest 5.0"
+    it "fails on extra and passes on regular" do
+      result = with_global_must do
+        run_cmd("ruby spec/cases/threads.rb -v", fail: true)
       end
-    else
-      it "fails on extra and passes on regular" do
-        result = with_global_must do
-          run_cmd("ruby spec/cases/threads.rb -v", fail: true)
-        end
-        result.gsub(/\d\.\d+/, "0.0").should include <<-OUT.gsub(/^\s+/, "")
-          threads#test_0001_is fine without extra threads = 0.0 s = .
-          threads#test_0002_fails on extra threads = 0.0 s = F
-          threads#test_0003_can kill extra threads = 0.0 s = .
-          threads#test_0004_can wait for extra threads = 0.0 s = .
-        OUT
-      end
+      result.gsub(/\d\.\d+/, "0.0").should include <<-OUT.gsub(/^\s+/, "")
+        threads#test_0001_is fine without extra threads = 0.0 s = .
+        threads#test_0002_fails on extra threads = 0.0 s = F
+        threads#test_0003_can kill extra threads = 0.0 s = .
+        threads#test_0004_can wait for extra threads = 0.0 s = .
+      OUT
     end
   end
 
@@ -317,11 +309,7 @@ describe Maxitest do
   end
 
   def with_global_must(&block)
-    if Gem::Version.new(Minitest::VERSION) >= Gem::Version.new("5.12.0")
-      with_env GLOBAL_MUST: 'true', &block
-    else
-      yield
-    end
+    with_env GLOBAL_MUST: 'true', &block
   end
 
   def with_env(h)


### PR DESCRIPTION
This PR adds support for Minitest 5.20.

Also:

- Remove old spec code
- Test against minitest 5.19 on CI
- Update Bundler lockfiles

## Checklist
- [ ] Added tests
- [ ] Updated README.md (if user facing behavior changed)
- [x] Added CHANGELOG.md entry under `# NEXT` (if user facing behavior changed)
