### PR TITLE
fix: use correct version for gemspec/gemfile

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/514.gemfile.lock
+++ b/gemfiles/514.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/515.gemfile.lock
+++ b/gemfiles/515.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/516.gemfile.lock
+++ b/gemfiles/516.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/517.gemfile.lock
+++ b/gemfiles/517.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/518.gemfile.lock
+++ b/gemfiles/518.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/519.gemfile.lock
+++ b/gemfiles/519.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/520.gemfile.lock
+++ b/gemfiles/520.gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/

--- a/gemfiles/523.gemfile
+++ b/gemfiles/523.gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 gemspec :path=>"../"
-gem "minitest", "~> 5.19.0"
+gem "minitest", "~> 5.23.0"

--- a/gemfiles/523.gemfile.lock
+++ b/gemfiles/523.gemfile.lock
@@ -2,13 +2,13 @@ PATH
   remote: ..
   specs:
     maxitest (5.4.0)
-      minitest (>= 5.14.0, < 5.23.0)
+      minitest (>= 5.14.0, < 5.24.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.5.1)
-    minitest (5.19.0)
+    minitest (5.23.1)
     rake (13.2.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
@@ -30,7 +30,7 @@ PLATFORMS
 
 DEPENDENCIES
   maxitest!
-  minitest (~> 5.19.0)
+  minitest (~> 5.23.0)
   rake
   rspec
 

--- a/maxitest.gemspec
+++ b/maxitest.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new "maxitest", Maxitest::VERSION do |s|
   s.license = "MIT"
   s.executables = ["mtest"]
 
-  s.add_runtime_dependency "minitest", [">= 5.14.0", "< 5.23.0"]
+  s.add_runtime_dependency "minitest", [">= 5.14.0", "< 5.24.0"]
   s.required_ruby_version = '>= 3', '< 4' # mirroring minitest
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
In my previous pr i had a small error due to a rebasing/conflict with upstream.

This PR fixes it.