### PR TITLE
Resolve unused block argument warning from `xit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Next
+- fix unused block warning for `xit` on ruby 3.4
 
 # v6.0.0
 - drop support for Ruby <=3.1 and minitest <5.20, test on ruby 3.4

--- a/lib/maxitest/xit.rb
+++ b/lib/maxitest/xit.rb
@@ -2,7 +2,7 @@
 
 module Maxitest
   module XitMethod
-    def xit(*args)
+    def xit(*args, &_block)
       describe 'skip' do
         define_method(:setup) {}
         define_method(:teardown) {}


### PR DESCRIPTION
It is indeed unused and intentionally so, no need to warn:
> /home/user/code/herb/test/extractor/extract_ruby_test.rb:108: warning: the block passed to 'xit' defined at /home/user/code/herb/vendor/bundle/ruby/3.4.0/gems/maxitest-6.0.0/lib/maxitest/xit.rb:5 may be ignored

This type of warning was introduced in ruby 3.4. Same as with unused variables like `_foo`, ruby doesn't warn when the block name starts with `_`.

## Checklist
- [ ] Added tests
- [ ] Updated README.md (if user facing behavior changed)
- [x] Added CHANGELOG.md entry under `# NEXT` (if user facing behavior changed)
